### PR TITLE
Changed name of conf key to make examples in Readme work and improve naming consistency

### DIFF
--- a/examples/run.yml
+++ b/examples/run.yml
@@ -46,7 +46,7 @@ wps:
    fg_name: 'FILE'
    io_form_metgrid: 2
 
-namelist:
+wrf:
   time_control:
     interval_seconds: 10800
     input_from_file: [True, True, True, True]

--- a/wrfconf/process.py
+++ b/wrfconf/process.py
@@ -59,7 +59,7 @@ def create_wrf_namelist(conf, stream=None):
     for k in domain_keys_to_copy:
         wrf_config['domains'][k] = domain[k]
 
-    return dump(merge_dicts(wrf_config, conf['namelist']), stream)
+    return dump(merge_dicts(wrf_config, conf['wrf']), stream)
 
 
 def create_wps_namelist(conf, stream=None):


### PR DESCRIPTION
In all examples, the key for wrf-specific option is named `wrf`, but in the code `namelist`. Since there is `namelist.input` and `namelist.wps`, this is quite confusing.

By fixing this, consistency would be restored to `create_wps_namelist` where the key is called `wps` and also the examples in Pypi and the Readme would work.